### PR TITLE
Exit in Output() after forced style 'D' download

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -7760,7 +7760,7 @@ class TCPDF {
 					'filename*=UTF-8\'\'' . rawurlencode(basename($name)));
 				header('Content-Transfer-Encoding: binary');
 				TCPDF_STATIC::sendOutputData($this->getBuffer(), $this->bufferlen);
-				break;
+				exit();
 			}
 			case 'F':
 			case 'FI':


### PR DESCRIPTION
Failure to terminate script after TCPDF method Output( 'doc.pdf', 'D') can add unexpected content (HTML) to a PDF file. After output, there is seemingly no reason not to exit. Returning an empty string '' seems problematic.